### PR TITLE
Add the saga for getting the user's profile

### DIFF
--- a/ts/features/profile/actions/index.ts
+++ b/ts/features/profile/actions/index.ts
@@ -1,0 +1,11 @@
+import { ActionType, createAsyncAction } from "typesafe-actions";
+import { InitializedProfile } from "../../../../definitions/backend/InitializedProfile";
+import { NetworkError } from "../../../utils/errors";
+
+export const getUserProfile = createAsyncAction(
+  "USER_PROFILE_REQUEST",
+  "USER_PROFILE_SUCCESS",
+  "USER_PROFILE_FAILURE"
+)<void, InitializedProfile, NetworkError>();
+
+export type UserProfileActions = ActionType<typeof getUserProfile>;

--- a/ts/features/profile/sagas/__tests__/handleGetUserProfile.test.ts
+++ b/ts/features/profile/sagas/__tests__/handleGetUserProfile.test.ts
@@ -1,0 +1,68 @@
+import { expectSaga } from "redux-saga-test-plan";
+import { left, right } from "fp-ts/lib/Either";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { handleGetUserProfile } from "../handleGetUserProfile";
+import mockedProfile from "../../../../__mocks__/initializedProfile";
+import { getUserProfile } from "../../actions";
+import { getGenericError, getNetworkError } from "../../../../utils/errors";
+
+describe("handleGetUserProfile selector", () => {
+  describe("given 200 response", () => {
+    it("returns success with user profile", async () => {
+      const request = jest.fn();
+      request.mockImplementation(() =>
+        right({ status: 200, value: mockedProfile })
+      );
+
+      await expectSaga(handleGetUserProfile, request, getUserProfile.request())
+        .put(getUserProfile.success(mockedProfile))
+        .run();
+    });
+  });
+
+  describe("given 500 response", () => {
+    it("returns failure with error", async () => {
+      const request = jest.fn();
+      request.mockImplementation(() => right({ status: 500 }));
+
+      await expectSaga(handleGetUserProfile, request, getUserProfile.request())
+        .put(
+          getUserProfile.failure({
+            ...getGenericError(new Error("response status 500"))
+          })
+        )
+        .run();
+    });
+  });
+
+  describe("given unexpected response", () => {
+    it("returns failure with decoding error", async () => {
+      const errors = [{ context: [], value: new Error("decoding error") }];
+      const request = jest.fn();
+      request.mockImplementation(() => left(errors));
+
+      await expectSaga(handleGetUserProfile, request, getUserProfile.request())
+        .put(
+          getUserProfile.failure({
+            ...getGenericError(new Error(readableReport(errors)))
+          })
+        )
+        .run();
+    });
+  });
+
+  describe("given an exception from the request", () => {
+    it("returns failure with network error", async () => {
+      const error = new Error("network error");
+
+      const request = jest.fn();
+      request.mockImplementation(() => {
+        throw error;
+      });
+
+      await expectSaga(handleGetUserProfile, request, getUserProfile.request())
+        .put(getUserProfile.failure(getNetworkError(error)))
+        .run();
+    });
+  });
+});

--- a/ts/features/profile/sagas/handleGetUserProfile.ts
+++ b/ts/features/profile/sagas/handleGetUserProfile.ts
@@ -1,0 +1,41 @@
+import { ActionType } from "typesafe-actions";
+import { call, put } from "redux-saga/effects";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { BackendClient } from "../../../api/backend";
+import { getUserProfile } from "../actions";
+import { SagaCallReturnType } from "../../../types/utils";
+import { getGenericError, getNetworkError } from "../../../utils/errors";
+
+export function* handleGetUserProfile(
+  getProfile: ReturnType<typeof BackendClient>["getProfile"],
+  _: ActionType<typeof getUserProfile.request>
+) {
+  try {
+    const response: SagaCallReturnType<typeof getProfile> = yield call(
+      getProfile,
+      {}
+    );
+
+    if (response.isRight()) {
+      if (response.value.status === 200) {
+        yield put(getUserProfile.success(response.value.value));
+      } else {
+        yield put(
+          getUserProfile.failure({
+            ...getGenericError(
+              new Error(`response status ${response.value.status}`)
+            )
+          })
+        );
+      }
+    } else {
+      yield put(
+        getUserProfile.failure({
+          ...getGenericError(new Error(readableReport(response.value)))
+        })
+      );
+    }
+  } catch (e) {
+    yield put(getUserProfile.failure(getNetworkError(e)));
+  }
+}

--- a/ts/features/profile/sagas/index.ts
+++ b/ts/features/profile/sagas/index.ts
@@ -1,0 +1,17 @@
+import { SagaIterator } from "redux-saga";
+import { ActionType } from "typesafe-actions";
+import { call, takeLatest } from "redux-saga/effects";
+import { getUserProfile } from "../actions";
+import { BackendClient } from "../../../api/backend";
+import { handleGetUserProfile } from "./handleGetUserProfile";
+
+export function* watchUserProfileSaga(
+  client: ReturnType<typeof BackendClient>
+): SagaIterator {
+  yield takeLatest(
+    getUserProfile.request,
+    function* (action: ActionType<typeof getUserProfile.request>) {
+      yield call(handleGetUserProfile, client.getProfile, action);
+    }
+  );
+}

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -33,6 +33,7 @@ import {
   bpdEnabled,
   euCovidCertificateEnabled,
   mvlEnabled,
+  newProfileScreenEnabled,
   pagoPaApiUrlPrefix,
   pagoPaApiUrlPrefixTest,
   svEnabled,
@@ -79,6 +80,7 @@ import { PinString } from "../types/PinString";
 import { SagaCallReturnType } from "../types/utils";
 import { isTestEnv } from "../utils/environment";
 import { deletePin, getPin } from "../utils/keychain";
+import { watchUserProfileSaga } from "../features/profile/sagas";
 import {
   startAndReturnIdentificationResult,
   watchIdentification
@@ -385,6 +387,11 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
   if (mvlEnabled) {
     // Start watching for MVL actions
     yield fork(watchMvlSaga, sessionToken);
+  }
+
+  if (newProfileScreenEnabled) {
+    // Start watching for profile actions
+    yield fork(watchUserProfileSaga, backendClient);
   }
 
   // Load the user metadata

--- a/ts/store/actions/types.ts
+++ b/ts/store/actions/types.ts
@@ -23,6 +23,7 @@ import { PrivativeActions } from "../../features/wallet/onboarding/privative/sto
 import { SatispayActions } from "../../features/wallet/onboarding/satispay/store/actions";
 import { ZendeskSupportActions } from "../../features/zendesk/store/actions";
 import { GlobalState } from "../reducers/types";
+import { UserProfileActions } from "../../features/profile/actions";
 import { AnalyticsActions } from "./analytics";
 import { ApplicationActions } from "./application";
 import { AuthenticationActions } from "./authentication";
@@ -100,7 +101,8 @@ export type Action =
   | OutcomeCodeActions
   | SvActions
   | MvlActions
-  | ZendeskSupportActions;
+  | ZendeskSupportActions
+  | UserProfileActions;
 
 export type Dispatch = DispatchAPI<Action>;
 


### PR DESCRIPTION
⚠️ This pr depends on https://github.com/emiliopavia/io-app/pull/1 ⚠️
Please review https://github.com/emiliopavia/io-app/pull/1 first in order to avoid duplicate review work.

## Short description
This PR adds a saga for getting the user's profile from the server.

## List of changes proposed in this pull request
- Created `getUserProfile` async action
- Created `watchUserProfileSaga` that runs `handleGetUserProfile` function
- Added `UserProfileActions` to the global `Action` type
- Added `watchUserProfileSaga` in the `initializeApplicationSaga()` function 

## How to test
As no new UI has been added yet, you can run unit tests on `handleGetUserProfile.tests.ts`.
