### PR TITLE
Add a new store property and implement the redux reducer

### DIFF
--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -322,7 +322,8 @@ const rootPersistConfig: PersistConfig = {
     "payments",
     "content",
     "userMetadata",
-    "crossSessions"
+    "crossSessions",
+    "userProfile"
   ],
   // Transform functions used to manipulate state on store/rehydrate
   // TODO: add optionTransform https://www.pivotaltracker.com/story/show/170998374

--- a/ts/features/profile/reducers/userProfile.ts
+++ b/ts/features/profile/reducers/userProfile.ts
@@ -1,0 +1,25 @@
+import * as pot from "italia-ts-commons/lib/pot";
+import { getType } from "typesafe-actions";
+import { InitializedProfile } from "../../../../definitions/backend/InitializedProfile";
+import { Action } from "../../../store/actions/types";
+import { getUserProfile } from "../actions";
+import { getErrorFromNetworkError } from "../../../utils/errors";
+
+export type UserProfileState = pot.Pot<InitializedProfile, Error>;
+
+const userProfileReducer = (
+  state: UserProfileState = pot.none,
+  action: Action
+): UserProfileState => {
+  switch (action.type) {
+    case getType(getUserProfile.request):
+      return pot.toLoading(state);
+    case getType(getUserProfile.success):
+      return pot.some(action.payload);
+    case getType(getUserProfile.failure):
+      return pot.toError(state, getErrorFromNetworkError(action.payload));
+  }
+  return state;
+};
+
+export default userProfileReducer;

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -16,6 +16,7 @@ import {
 import { Action } from "../actions/types";
 import createSecureStorage from "../storages/keychain";
 import { DateISO8601Transform } from "../transforms/dateISO8601Tranform";
+import userProfileReducer from "../../features/profile/reducers/userProfile";
 import appStateReducer from "./appState";
 import authenticationReducer, {
   AuthenticationState,
@@ -133,7 +134,8 @@ export const appReducer: Reducer<GlobalState, Action> = combineReducers<
   payments: paymentsReducer,
   content: contentReducer,
   emailValidation: emailValidationReducer,
-  crossSessions: crossSessionsReducer
+  crossSessions: crossSessionsReducer,
+  userProfile: userProfileReducer
 });
 
 export function createRootReducer(

--- a/ts/store/reducers/types.ts
+++ b/ts/store/reducers/types.ts
@@ -3,6 +3,7 @@ import { VersionInfoState } from "../../common/versionInfo/store/reducers/versio
 
 import { BonusState } from "../../features/bonus/bonusVacanze/store/reducers";
 import { PersistedFeaturesState } from "../../features/common/store/reducers";
+import { UserProfileState } from "../../features/profile/reducers/userProfile";
 import { AppState } from "./appState";
 import { AssistanceToolsState } from "./assistanceTools";
 import { PersistedAuthenticationState } from "./authentication";
@@ -62,6 +63,7 @@ export type GlobalState = Readonly<{
   internalRouteNavigation: InternalRouteNavigationState;
   crossSessions: CrossSessionsState;
   assistanceTools: AssistanceToolsState;
+  userProfile: UserProfileState;
 }>;
 
 export type PersistedGlobalState = GlobalState & PersistPartial;


### PR DESCRIPTION
⚠️ This pr depends on https://github.com/emiliopavia/io-app/pull/2 ⚠️
Please review https://github.com/emiliopavia/io-app/pull/2 first in order to avoid duplicate review work.

## Short description
This PR adds a new property to the global state to store the user's profile. It also implements the redux reducer to set it from the saga.

## List of changes proposed in this pull request
- `userProfile` has been added to `GlobalState` (and whitelisted to make it persisted)
- Created `userProfileReducer` and added to the `appReducer`

## How to test
Dispatch the `getUserProfile.request()` action and verify in Reactotron changes in `userProfile` state. When using the dev server you can simulate errors and/or delays.