### PR TITLE
Add the user deletion switch to the profile screen

### DIFF
--- a/ts/features/profile/components/UserProfileSwitch.tsx
+++ b/ts/features/profile/components/UserProfileSwitch.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "native-base";
+import { Pot } from "italia-ts-commons/lib/pot";
+import { RemoteSwitch } from "../../../components/core/selection/RemoteSwitch";
+import Separator from "./Separator";
+
+type Props = Readonly<{
+  description: string;
+  value: Pot<boolean, Error>;
+  onRetry: () => void;
+}>;
+
+const styles = StyleSheet.create({
+  row: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 20,
+    marginLeft: 16
+  },
+  description: {
+    flex: 1
+  },
+  switch: {
+    flex: 0,
+    marginRight: 16
+  },
+  separator: {
+    marginLeft: 16
+  }
+});
+
+const UserProfileItem = (props: Props): React.ReactElement => (
+  <View>
+    <View style={styles.row}>
+      <Text style={styles.description}>{props.description}</Text>
+      <View style={styles.switch}>
+        <RemoteSwitch value={props.value} onRetry={props.onRetry} />
+      </View>
+    </View>
+    <Separator style={styles.separator} />
+  </View>
+);
+
+export default UserProfileItem;

--- a/ts/features/profile/reducers/userProfile.ts
+++ b/ts/features/profile/reducers/userProfile.ts
@@ -86,10 +86,9 @@ export const selectUserProfileDeletionStatus = (
     () => pot.noneLoading,
     v => pot.noneUpdating(toBoolean(v?.status)),
     e => pot.noneError(e),
-    v =>
-      toBoolean(v?.status) ? pot.someUpdating(false, true) : pot.some(false),
+    v => pot.some(toBoolean(v?.status)),
     v => pot.someLoading(toBoolean(v?.status)),
-    (v, _) => pot.someUpdating(toBoolean(v?.status), true),
+    (o, n) => pot.someUpdating(toBoolean(o?.status), toBoolean(n?.status)),
     (v, e) => pot.someError(toBoolean(v?.status), e)
   );
 };

--- a/ts/features/profile/screens/UserProfileScreen.tsx
+++ b/ts/features/profile/screens/UserProfileScreen.tsx
@@ -14,7 +14,8 @@ import {
   selectUserEmail,
   selectUserFiscalCode,
   selectUserFullName,
-  selectUserProfile
+  selectUserProfile,
+  selectUserProfileDeletionStatus
 } from "../reducers/userProfile";
 import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
 import I18n from "../../../i18n";
@@ -27,6 +28,9 @@ import EmailIcon from "../../../../img/assistance/email.svg";
 import FiscalCodeIcon from "../../../../img/assistance/fiscalCode.svg";
 import InfoIcon from "../../../../img/assistance/info.svg";
 import { showToast } from "../../../utils/showToast";
+import { loadUserDataProcessing } from "../../../store/actions/userDataProcessing";
+import { UserDataProcessingChoiceEnum } from "../../../../definitions/backend/UserDataProcessingChoice";
+import UserProfileSwitch from "../components/UserProfileSwitch";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -47,6 +51,7 @@ const UserProfileScreen = (props: Props): React.ReactElement => {
 
   useOnFirstRender(() => {
     props.loadProfile();
+    props.loadProfileDeletionStatus();
   });
 
   if (pot.isError(profile)) {
@@ -74,46 +79,56 @@ const UserProfileScreen = (props: Props): React.ReactElement => {
             <UserProfileItem
               title={I18n.t("profile.data.list.nameSurname")}
               subtitle={props.fullName}
-              icon={<NameSurnameIcon {...iconProps}></NameSurnameIcon>}
+              icon={<NameSurnameIcon {...iconProps} />}
             />
           )}
           {props.fiscalCode && (
             <UserProfileItem
               title={I18n.t("profile.fiscalCode.fiscalCode")}
               subtitle={props.fiscalCode}
-              icon={<FiscalCodeIcon {...iconProps}></FiscalCodeIcon>}
+              icon={<FiscalCodeIcon {...iconProps} />}
             />
           )}
           {props.email && (
             <UserProfileItem
               title={I18n.t("profile.data.list.email")}
               subtitle={props.email}
-              icon={<EmailIcon {...iconProps}></EmailIcon>}
+              icon={<EmailIcon {...iconProps} />}
             />
           )}
-          {props.birthdate && (
+          {props.birthdate?.toLocaleDateString && (
             <UserProfileItem
               title={I18n.t("profile.data.list.birthdate")}
               subtitle={props.birthdate.toLocaleDateString()}
-              icon={<InfoIcon {...iconProps}></InfoIcon>}
+              icon={<InfoIcon {...iconProps} />}
             />
           )}
+          <UserProfileSwitch
+            description={I18n.t("profile.main.privacy.removeAccount.title")}
+            value={props.deletionStatus}
+            onRetry={props.loadProfileDeletionStatus}
+          />
         </ScrollView>
-        {pot.isLoading(profile) && pot.isNone(profile) && <Loader></Loader>}
+        {pot.isLoading(profile) && pot.isNone(profile) && <Loader />}
       </SafeAreaView>
     </BaseScreenComponent>
   );
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  loadProfile: () => dispatch(getUserProfile.request())
+  loadProfile: () => dispatch(getUserProfile.request()),
+  loadProfileDeletionStatus: () =>
+    dispatch(
+      loadUserDataProcessing.request(UserDataProcessingChoiceEnum.DELETE)
+    )
 });
 
 const mapStateToProps = (state: GlobalState) => ({
   fullName: selectUserFullName(state),
   email: selectUserEmail(state),
   fiscalCode: selectUserFiscalCode(state),
-  birthdate: selectUserBirthdate(state)
+  birthdate: selectUserBirthdate(state),
+  deletionStatus: selectUserProfileDeletionStatus(state)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserProfileScreen);


### PR DESCRIPTION
### ⚠️ This pr depends on https://github.com/emiliopavia/io-app/pull/4 ⚠️
#### Please review https://github.com/emiliopavia/io-app/pull/4 first in order to avoid duplicate review work.

## Short description
This PR adds a switch to the profile screen that shows whether or not the account deletion has been requested by the user.

## List of changes proposed in this pull request
- Added `UserProfileSwitch` component
- Added a selector for the `userDataProcessing.DELETE` property on the global state (the selector maps the actual state to a `boolean` that will drive the switch in the UI)
- The `UserProfileScreen` has been updated to update the status on first render and to show the switch to the user 

## How to test
Under "profile" ->"Privacy" -> "Elimina il tuo account" you can toggle the deletion status on the dev server. Verify that the switch is updated accordingly.

https://user-images.githubusercontent.com/467098/156723683-12cbc526-cb24-464b-b335-414b3dee07ae.mov


